### PR TITLE
Final Boss Mode + fixes

### DIFF
--- a/EXAMPLE.env
+++ b/EXAMPLE.env
@@ -1,10 +1,12 @@
-# USER SETTINGS
+# USER SETTINGS (REQUIRED)
 
 # set this with the code you get from https://twitchapps.com/tmi/
 OAUTH=oauth:8t4jao91vEXAMPLE700qfdk4n6h6i9
             
 # channel the viewers will input commands in
 TARGET_CHANNEL=ninja
+
+# USER SETTINGS (OPTIONAL)
 
 # prefix for your commands
 PREFIX=#
@@ -19,26 +21,26 @@ third-camera-vertical-inverted=t
 third-camera-horizontal-inverted=t
 
 #command min and max values
-SHIFTX_MIN=-15
+SHIFTX_MIN=-20
 SHIFTX_MAX=20
 SHIFTY_MIN=-5
-SHIFTY_MAX=25
-SHIFTZ_MIN=-15
+SHIFTY_MAX=50
+SHIFTZ_MIN=-20
 SHIFTZ_MAX=20
 GIVE_MIN=-2
-GIVE_MAX=3
+GIVE_MAX=999
 RJTO_MIN=-50
 RJTO_MAX=150
 SCALE_MIN=-15
 SCALE_MAX=15
 MINUSCELL_AMT=1
 PLUSCELL_AMT=1
-MINUSORBS_AMT=90
-PLUSORBS_AMT=90
+MINUSORBS_AMT=45
+PLUSORBS_AMT=45
 SUCK_MIN=-200
 SUCK_MAX=200
 BLIND_MIN=0.1
-BLIND_MAX=15
+BLIND_MAX=10
 
 #allow 'topoint' to spawn you past lava tube
 TOPOINT_PAST_CRATER=f
@@ -130,21 +132,22 @@ save=t
 actorson=t
 actorsoff=t
 fixoldsave=t
+finalboss=t
 
 # command cooldowns (seconds)
 COOLDOWN_MSG=t
-protect_cd=600
+protect_cd=420
 rjto_cd=120
 superjump_cd=30
 superboosted_cd=30
-noboosteds_cd=180
-nojumps_cd=420
-fastjak_cd=0
-slowjak_cd=0
-slippery_cd=240
-pinball_cd=480
-pacifist_cd=240
-nuka_cd=165
+noboosteds_cd=250
+nojumps_cd=390
+fastjak_cd=60
+slowjak_cd=390
+slippery_cd=260
+pinball_cd=400
+pacifist_cd=260
+nuka_cd=300
 invul_cd=135
 trip_cd=45
 shortfall_cd=300
@@ -155,42 +158,43 @@ freecam_cd=300
 enemyspeed_cd=20
 give_cd=600
 # shares cooldown with 'collected'
-minuscell_cd=1200
+minuscell_cd=1500
 pluscell_cd=900
 minusorbs_cd=1020
 plusorbs_cd=600
-eco_cd=20
+eco_cd=30
 rapidfire_cd=60
 sucksuck_cd=30
-noeco_cd=160
-die_cd=300		    
+noeco_cd=200
+die_cd=450
 # shares cooldown with 'melt', 'endlessfall', and 'drown'
-topoint_cd=900  	
+topoint_cd=1500
 # shares cooldown with 'randompoint'
 sfx_cd=30
 setpoint_cd=720
-tp_cd=450		    
-rocketman_cd=360
-movetojak_cd=15	
-ouch_cd=210		    
+tp_cd=135
+# shares cooldown with 'shift'		    
+rocketman_cd=150
+movetojak_cd=100	
+ouch_cd=165  
 # shares cooldown with 'burn'
-hp_cd=75
-iframes_cd=135
+hp_cd=195
+iframes_cd=155
 invertcam_cd=300
-cam_cd=270
-askew_cd=570
-stickycam_cd=330
-deload_cd=360		
+cam_cd=345
+askew_cd=360
+stickycam_cd=360
+deload_cd=480
 # shares cooldown with 'ghostjak'
 quickcam_cd=75
-dark_cd=420
-blind_cd=750
+dark_cd=555
+# shares cooldown with 'blind'
 nodax_cd=20
 smallnet_cd=45
 widefish_cd=45
 lowpoly_cd=30
 color_cd=45
-scale_cd=15		
+scale_cd=195
 # shares cooldown with 'bigjak', 'smalljak', 'widejak', and 'flatjak'
 moveplantboss_cd=300
 moveplantboss2_cd=5
@@ -200,11 +204,11 @@ smallhead_cd=180
 bigfist_cd=180
 bigheadnpc_cd=180
 hugehead_cd=180
-mirror_cd=180
+mirror_cd=400
 notex_cd=180
 press_cd=45
 lang_cd=45
-resetactors_cd=420
+resetactors_cd=540
 repl_cd=0
 
 # command durations (seconds)
@@ -213,43 +217,43 @@ protect_dur=60
 rjto_dur=60
 superjump_dur=60
 superboosted_dur=180
-noboosteds_dur=120
+noboosteds_dur=60
 nojumps_dur=30
 fastjak_dur=60
 slowjak_dur=30
-slippery_dur=75
+slippery_dur=45
 pinball_dur=20
-pacifist_dur=60
-nuka_dur=60
+pacifist_dur=30
+nuka_dur=20
 invul_dur=60
-shortfall_dur=60
-ghostjak_dur=3
+shortfall_dur=45
+ghostjak_dur=2
 freecam_dur=6
-sucksuck_dur=10
-noeco_dur=10
-rapidfire_dur=300
-iframes_dur=60
+sucksuck_dur=75
+noeco_dur=8
+rapidfire_dur=480
+iframes_dur=45
 rocketman_dur=5
-invertcam_dur=120
+invertcam_dur=75
 stickycam_dur=10
 cam_dur=20
-askew_dur=60
-dark_dur=30
+askew_dur=30
+dark_dur=15
 nodax_dur=45
 smallnet_dur=10
 widefish_dur=4
 lowpoly_dur=150
-color_dur=15
-scale_dur=30
-widejak_dur=45
-flatjak_dur=45
-smalljak_dur=45
-bigjak_dur=45
-bighead_dur=45
-smallhead_dur=45
-bigfist_dur=45
-bigheadnpc_dur=45
-hugehead_dur=45
+color_dur=20
+scale_dur=15
+widejak_dur=30
+flatjak_dur=30
+smalljak_dur=30
+bigjak_dur=30
+bighead_dur=30
+smallhead_dur=60
+bigfist_dur=60
+bigheadnpc_dur=120
+hugehead_dur=60
 mirror_dur=45
 notex_dur=45
 
@@ -275,6 +279,7 @@ hp_dur=0
 melt_dur=0
 endlessfall_dur=0
 deload_dur=0
+blind_cd=0
 blind_dur=0
 quickcam_dur=0
 moveplantboss_dur=0
@@ -323,6 +328,8 @@ press_dur=0
 setpoint_dur=0
 fixoldsave_dur=0
 fixoldsave_cd=0
+finalboss_dur=0
+finalboss_cd=0
 lang_dur=0
 resetcooldowns=t
 cd=t

--- a/resources/twitchcommands.py
+++ b/resources/twitchcommands.py
@@ -69,6 +69,9 @@ SUCK_MAX = str(os.getenv("SUCK_MAX"))
 BLIND_MIN = str(os.getenv("BLIND_MIN"))
 BLIND_MAX = str(os.getenv("BLIND_MAX"))
 
+FINALBOSS_MUL = 3
+FINALBOSS_MODE = False
+
 
 #bool that checks if its the launcher version
 launcher_version = exists(application_path+"\OpenGOAL-Launcher.exe")
@@ -164,7 +167,7 @@ def cd_check(cmd):
         remaining_time = int(cooldowns[command_names.index(cmd)] - (time.time() - last_used[command_names.index(cmd)]))
         minutes = remaining_time // 60
         seconds = remaining_time % 60
-        sendMessage(irc, "/me @" + user + " Command '" + command_names[command_names.index(cmd)] + "' is on cooldown (" + str(minutes) + "m " + str(seconds) + "s left).")
+        sendMessage(irc, "/me @" + user + " Command '" + command_names[command_names.index(cmd)] + "' is on cooldown (" + str(minutes) + "m" + str(seconds) + "s left).")
         message = ""
         return False
     else:
@@ -271,7 +274,7 @@ command_names = ["protect","rjto","superjump","superboosted","noboosteds","nojum
                  "basincell","resetactors","repl","debug","save","resetcooldowns","cd","dur","enable","disable",
                  "widejak","flatjak","smalljak","bigjak","color","scale","slippery","pinball","rocketman","actorson",
                  "actorsoff","unzoom","bighead","smallhead","bigfist","bigheadnpc","hugehead","mirror","notex","press",
-                 "lang","fixoldsave"]
+                 "lang","fixoldsave","finalboss"]
 
 #array of valid checkpoints so user cant send garbage data
 point_list = ["training-start","game-start","village1-hut","village1-warp","beach-start",
@@ -595,7 +598,7 @@ def gamecontrol():
             sendForm("(when (not (movie?))(set! (-> (target-pos 0) x) (meters " + str(args[1]) + "))  (set! (-> (target-pos 0) y) (meters " + str(args[2]) + ")) (set! (-> (target-pos 0) z) (meters " + str(args[3]) + ")))")
             message = ""
 
-        if PREFIX + "shift" == str(args[0]).lower() and len(args) >= 4 and on_check("shift") and max_val(args[1], SHIFTX_MIN, SHIFTX_MAX) and max_val(args[2], SHIFTY_MIN, SHIFTY_MAX) and max_val(args[3], SHIFTZ_MIN, SHIFTZ_MAX) and cd_check("shift"):
+        if PREFIX + "shift" == str(args[0]).lower() and len(args) >= 4 and on_check("shift") and max_val(args[1], SHIFTX_MIN, SHIFTX_MAX) and max_val(args[2], SHIFTY_MIN, SHIFTY_MAX) and max_val(args[3], SHIFTZ_MIN, SHIFTZ_MAX) and cd_check("tp"):
             sendForm("(when (not (movie?))(set! (-> (target-pos 0) x) (+ (-> (target-pos 0) x)(meters " + str(args[1]) + ")))  (set! (-> (target-pos 0) y) (+ (-> (target-pos 0) y)(meters " + str(args[2]) + "))) (set! (-> (target-pos 0) z) (+ (-> (target-pos 0) z)(meters " + str(args[3]) + "))))")
             message = ""
 
@@ -684,7 +687,7 @@ def gamecontrol():
             "(set! (-> (level-get-target-inside *level*) mood-func)update-mood-darkcave)")
             message = ""
 
-        if PREFIX + "blind" == str(args[0]).lower() and len(args) >= 2 and on_check("blind") and cd_check("blind") and max_val(args[1], BLIND_MIN, BLIND_MAX):
+        if PREFIX + "blind" == str(args[0]).lower() and len(args) >= 2 and on_check("blind") and cd_check("dark") and max_val(args[1], BLIND_MIN, BLIND_MAX):
             activate("blind")
             sendForm("(set-blackout-frames (seconds " + str(args[1]) + "))")
             message = ""
@@ -954,6 +957,64 @@ def gamecontrol():
         if PREFIX + "cam-out" == str(args[0]).lower() and COMMAND_MODS.count(user) > 0:
           sendForm("(set! (-> *cpad-list* cpads 0 righty) (the-as uint 255))")
           message = ""
+
+        if PREFIX + "finalboss" == str(args[0]).lower() and COMMAND_MODS.count(user) > 0 and on_check("finalboss") :
+            global FINALBOSS_MODE
+            if not FINALBOSS_MODE:
+                on_off[command_names.index("die")] = "f"
+                on_off[command_names.index("drown")] = "f"
+                on_off[command_names.index("melt")] = "f"
+                on_off[command_names.index("endlessfall")] = "f"
+                on_off[command_names.index("resetactors")] = "f"
+                on_off[command_names.index("deload")] = "f"
+                on_off[command_names.index("ghostjak")] = "f"
+                on_off[command_names.index("shift")] = "f"
+                on_off[command_names.index("tp")] = "f"
+                on_off[command_names.index("topoint")] = "f"
+                on_off[command_names.index("randompoint")] = "f"
+                cooldowns[command_names.index("scale")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("hp")] *= FINALBOSS_MUL 
+                cooldowns[command_names.index("iframes")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("ouch")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("movetojak")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("rocketman")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("noeco")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("eco")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("shortfall")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("nuka")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("pinball")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("slippery")] *= FINALBOSS_MUL
+                cooldowns[command_names.index("nojumps")] *= FINALBOSS_MUL
+                FINALBOSS_MODE = True
+                sendMessage(irc, "/me ~ Final Boss Mode activated! Cooldowns are longer and some commands are disabled.")
+            else:
+                on_off[command_names.index("die")] = (os.getenv("die"))
+                on_off[command_names.index("drown")] = (os.getenv("drown"))
+                on_off[command_names.index("melt")] = (os.getenv("melt"))
+                on_off[command_names.index("endlessfall")] = (os.getenv("endlessfall"))
+                on_off[command_names.index("resetactors")] = (os.getenv("resetactors"))
+                on_off[command_names.index("deload")] = (os.getenv("deload"))
+                on_off[command_names.index("ghostjak")] = (os.getenv("ghostjak"))
+                on_off[command_names.index("shift")] = (os.getenv("shift"))
+                on_off[command_names.index("tp")] = (os.getenv("tp"))
+                on_off[command_names.index("topoint")] = (os.getenv("topoint"))
+                on_off[command_names.index("randompoint")] = (os.getenv("randompoint"))
+                cooldowns[command_names.index("scale")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("hp")] /= FINALBOSS_MUL 
+                cooldowns[command_names.index("iframes")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("ouch")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("movetojak")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("rocketman")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("noeco")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("eco")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("shortfall")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("nuka")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("pinball")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("slippery")] /= FINALBOSS_MUL
+                cooldowns[command_names.index("nojumps")] /= FINALBOSS_MUL
+                FINALBOSS_MODE = False
+                sendMessage(irc, "/me ~ Final Boss Mode deactivated.")
+        message = ""
             
         if str(args[0]) == PREFIX + "repl" and len(args) >= 2 and on_check("repl") and cd_check("repl"):
             if COMMAND_MODS.count(user) > 0:
@@ -971,7 +1032,7 @@ def gamecontrol():
         active_sweep("noboosteds","(set! (-> *edge-surface* fric) 30720.0)")
         active_sweep("nojumps","(logclear! (-> *target* state-flags) (state-flags prevent-jump))")
         active_sweep("fastjak","(set! (-> *walk-mods* target-speed) 40960.0)(set! (-> *double-jump-mods* target-speed) 32768.0)(set! (-> *jump-mods* target-speed) 40960.0)(set! (-> *jump-attack-mods* target-speed) 24576.0)(set! (-> *attack-mods* target-speed) 40960.0)(set! (-> *forward-high-jump-mods* target-speed) 45056.0)(set! (-> *jump-attack-mods* target-speed) 24576.0)(set! (-> *stone-surface* target-speed) 1.0)")
-        active_sweep("slowjak", "(set! (-> *walk-mods* target-speed) 40960.0)(set! (-> *double-jump-mods* target-speed) 32768.0)(set! (-> *jump-mods* target-speed) 40960.0)(set! (-> *jump-attack-mods* target-speed) 24576.0)(set! (-> *attack-mods* target-speed) 40960.0)(set! (-> *forward-high-jump-mods* target-speed) 45056.0)(set! (-> *jump-attack-mods* target-speed) 24576.0)(set! (-> *TARGET-bank* wheel-flip-dist) (meters 17.3))")
+        active_sweep("slowjak", "(set! (-> *walk-mods* target-speed) 40960.0)(set! (-> *double-jump-mods* target-speed) 32768.0)(set! (-> *jump-mods* target-speed) 40960.0)(set! (-> *jump-attack-mods* target-speed) 24576.0)(set! (-> *attack-mods* target-speed) 40960.0)(set! (-> *forward-high-jump-mods* target-speed) 45056.0)(set! (-> *jump-attack-mods* target-speed) 24576.0)(set! (set! (-> *TARGET-bank* wheel-flip-dist) (meters 17.3))(set! (-> *TARGET-bank* wheel-flip-height) (meters 3.52))")
         active_sweep("pacifist", "(set! (-> *TARGET-bank* punch-radius) (meters 1.3))(set! (-> *TARGET-bank* spin-radius) (meters 2.2))(set! (-> *TARGET-bank* flop-radius) (meters 1.4))(set! (-> *TARGET-bank* uppercut-radius) (meters 1))")
         active_sweep("nuka","(logior! (-> *target* state-flags) (state-flags dangerous))")
         active_sweep("invul","(logior! (-> *target* state-flags) (state-flags dangerous))")


### PR DESCRIPTION
- Added Final Boss Mode, which can be activated by admins to increase the length of cooldowns and disable some commands to make final boss possible.
- Made 'shift' share the 'tp' cooldown
- Made 'blind' share the 'dark' cooldown
- Fixed wheel-flip-height not being reverted after 'slowjak' deactivates
- Removed active state for 'blind'
- Adjusted env values